### PR TITLE
Updated JSON syntax error alzArm.param file

### DIFF
--- a/patterns/alz/alzArm.param.json
+++ b/patterns/alz/alzArm.param.json
@@ -97,7 +97,7 @@
       ]
     },
     "ALZMonitorActionGroupEmail": {
-      "value": [robert.eriksson@outlook.com]
+      "value": ["robert.eriksson@outlook.com"]
     },
     "ALZLogicappResourceId": {
       "value": ""


### PR DESCRIPTION
This pull request includes a minor change to the `patterns/alz/alzArm.param.json` file. The change corrects the syntax of the email value by enclosing it in double quotes.

* [`patterns/alz/alzArm.param.json`](diffhunk://#diff-b4d11fdd667dab543ab73dc60c4911d9d9a6b3b1ccdd074bab573431e100eb98L100-R100): Corrected the syntax of the email value by enclosing it in double quotes.