### PR TITLE
Updated bringYourOwnUserAssignedManagedIdentityResourceId

### DIFF
--- a/patterns/alz/alzArm.param.json
+++ b/patterns/alz/alzArm.param.json
@@ -63,10 +63,10 @@
       "value": "No"
     },
     "bringYourOwnUserAssignedManagedIdentity": {
-      "value": "No"
+      "value": "Yes"
     },
     "bringYourOwnUserAssignedManagedIdentityResourceId": {
-      "value": ""
+      "value": "ID: /subscriptions/01e375ca-82aa-4e38-87e5-d3b7b9383923/resourcegroups/rg-amba-monitoring-001/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id-amba-prod-001"
     },
     "userAssignedManagedIdentityName": {
       "value": "id-amba-prod-001"


### PR DESCRIPTION
This pull request includes a change to the `patterns/alz/alzArm.param.json` file, specifically updating the settings for the user-assigned managed identity.

* Changed `bringYourOwnUserAssignedManagedIdentity` value from "No" to "Yes".
* Updated `bringYourOwnUserAssignedManagedIdentityResourceId` with a specific resource ID.