### PR TITLE
enableAMBAWeb "NO"

### DIFF
--- a/patterns/alz/alzArm.param.json
+++ b/patterns/alz/alzArm.param.json
@@ -57,7 +57,7 @@
       "value": "Yes"
     },
     "enableAMBAWeb": {
-      "value": "Yes"
+      "value": "NO"
     },
     "telemetryOptOut": {
       "value": "No"


### PR DESCRIPTION
This pull request includes a small change to the `patterns/alz/alzArm.param.json` file. The change updates the `enableAMBAWeb` parameter value from "Yes" to "NO".