### PR TITLE
No not NO enableAMBAWeb

### DIFF
--- a/patterns/alz/alzArm.param.json
+++ b/patterns/alz/alzArm.param.json
@@ -57,7 +57,7 @@
       "value": "Yes"
     },
     "enableAMBAWeb": {
-      "value": "NO"
+      "value": "No"
     },
     "telemetryOptOut": {
       "value": "No"


### PR DESCRIPTION
This pull request includes a small change to the `patterns/alz/alzArm.param.json` file. The change corrects the value for the `enableAMBAWeb` parameter from "NO" to "No".